### PR TITLE
Fix GNU Compiler's CMake Flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties(${INTERCEPT_PLUGIN_NAME} PROPERTIES FOLDER "${CMAKE_PROJEC
 if(CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "-std=c++1z -O2 -s -fPIC -fpermissive -static-libgcc -static-libstdc++")#-march=i686 -m32
 	set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-	set(CMAKE_SHARED_LINKER_FLAGS "-shared")
+	set(CMAKE_SHARED_LINKER_FLAGS "-shared -static-libgcc -static-libstdc++")
 else()
 	set(CMAKE_CXX_FLAGS_DEBUG "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1 /MP /EHsc")
 	set(CMAKE_CXX_FLAGS_RELEASE "/MT /Zi /O2 /Ob1 /EHsc /MP") #with debug info

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties(${INTERCEPT_PLUGIN_NAME} PROPERTIES FOLDER "${CMAKE_PROJEC
 if(CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_CXX_FLAGS "-std=c++1z -O2 -s -fPIC -fpermissive -static-libgcc -static-libstdc++")#-march=i686 -m32
 	set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-	set(CMAKE_SHARED_LINKER_FLAGS "-static -static-libgcc -static-libstdc++")
+	set(CMAKE_SHARED_LINKER_FLAGS "-shared")
 else()
 	set(CMAKE_CXX_FLAGS_DEBUG "/D_DEBUG /MTd /Zi /Ob0 /Od /RTC1 /MP /EHsc")
 	set(CMAKE_CXX_FLAGS_RELEASE "/MT /Zi /O2 /Ob1 /EHsc /MP") #with debug info


### PR DESCRIPTION
Fixes an issue if building for Linux. Root cause was a wrong flag for CMake.

Resulting Error:
```/usr/bin/x86_64-linux-gnu-ld: /usr/lib/gcc/x86_64-linux-gnu/7/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
/usr/bin/x86_64-linux-gnu-ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
src/CMakeFiles/template-plugin_x64.dir/build.make:1004: recipe for target 'src/template-plugin_x64.so' failed
CMakeFiles/Makefile2:85: recipe for target 'src/CMakeFiles/template-plugin_x64.dir/all' failed
Makefile:83: recipe for target 'all' failed
make[2]: *** [src/template-plugin_x64.so] Error 1
make[1]: *** [src/CMakeFiles/template-plugin_x64.dir/all] Error 2
make: *** [all] Error 2```

Solution as proposed in slack by @dedmen 